### PR TITLE
Fixed problem where user could add blank item

### DIFF
--- a/app/src/main/java/io/whitegoldlabs/bias/views/ShoppingListActivity.java
+++ b/app/src/main/java/io/whitegoldlabs/bias/views/ShoppingListActivity.java
@@ -62,13 +62,17 @@ public class ShoppingListActivity extends AppCompatActivity
      */
     public void addItem(View view)
     {
-        String newId = Integer.toString(latestId + 1);
         String newName = editItem.getText().toString();
 
-        db.child("items").child(newId).child("name").setValue(newName);
-        db.child("items").child(newId).child("crossed").setValue(false);
+        if(newName.length() > 0)
+        {
+            String newId = Integer.toString(latestId + 1);
 
-        editItem.setText("");
+            db.child("items").child(newId).child("name").setValue(newName);
+            db.child("items").child(newId).child("crossed").setValue(false);
+
+            editItem.setText("");
+        }
     }
 
     /**


### PR DESCRIPTION
The app now checks to see if the item field is blank before submitting. If it is, the app will do nothing.

I don't believe an error message is really in order here, at least for right now.
