### PR TITLE
Fixed remove-item race condition

### DIFF
--- a/app/src/main/java/io/whitegoldlabs/bias/views/ShoppingListActivity.java
+++ b/app/src/main/java/io/whitegoldlabs/bias/views/ShoppingListActivity.java
@@ -41,6 +41,8 @@ public class ShoppingListActivity extends AppCompatActivity
     private ArrayAdapter adapter;
     private ArrayList<Item> items;
 
+    private Item selectedItem;
+
     private int latestId;
 
     @Override
@@ -82,10 +84,7 @@ public class ShoppingListActivity extends AppCompatActivity
      */
     public void removeItem(MenuItem menuItem)
     {
-        AdapterContextMenuInfo info = (AdapterContextMenuInfo) menuItem.getMenuInfo();
-
-        Item item = items.get(info.position);
-        db.child("items").child(Integer.toString(item.getId())).removeValue();
+        db.child("items").child(Integer.toString(selectedItem.getId())).removeValue();
     }
 
     /**
@@ -162,7 +161,8 @@ public class ShoppingListActivity extends AppCompatActivity
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo)
     {
         AdapterContextMenuInfo info = (AdapterContextMenuInfo)menuInfo;
-        menu.setHeaderTitle(items.get(info.position).getName());
+        selectedItem = items.get(info.position);
+        menu.setHeaderTitle(selectedItem.getName());
 
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.menu_shopping_list, menu);

--- a/version-history.md
+++ b/version-history.md
@@ -20,3 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.1] - 2016-10-20
 - Fixed problem where user could add a blank item to the database
+
+## [0.2.2] - 2016-10-20
+- Fixed problem where user could delete an item after another user selects it


### PR DESCRIPTION
Fixed problem where a user could delete an item that another user had already selected, causing a race condition. Now the item is selected as soon as the menu is created, and won't crash if the item doesn't exist anymore.

This also solves the problem where a user could select the last item in the list before another user deletes it, causing an `IndexOutOfBoundsException` if the user then tries to delete it.
